### PR TITLE
Add cross-compilation build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Configure
+    - name: Install ARM cross-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+    - name: Configure (native)
       run: cmake -S . -B build
-    - name: Build
+    - name: Build (native)
       run: cmake --build build
+    - name: Configure (arm64)
+      run: cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
+    - name: Build (arm64)
+      run: cmake --build build-arm64

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ cmake -S . -B build
 cmake --build build
 ```
 
+To cross-compile for an ARM target (e.g. Raspberry Pi), you will need the
+`aarch64-linux-gnu-gcc` toolchain installed.  Pass the provided toolchain file:
+
+```bash
+cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
+cmake --build build-arm64
+```
+
 The binary will be created at `build/hello` and simply prints `hello` when
 executed.  More functionality will land in subsequent epics.
 

--- a/cmake/toolchain-arm64.cmake
+++ b/cmake/toolchain-arm64.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)


### PR DESCRIPTION
## Summary
- document `aarch64-linux-gnu-gcc` requirement for cross-compiling
- build ARM binaries in CI
- add `toolchain-arm64.cmake`

## Testing
- `cmake -S . -B build && cmake --build build`
- `cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake && cmake --build build-arm64` *(fails: compiler not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8521009883258cd18e823b660294