### PR TITLE
Implement macOS bootstrap and Pi cross‑compile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ CMakeCache.txt
 CMakeFiles/
 CMakeScripts/
 Testing/
-Makefile
+build/*Makefile
 cmake_install.cmake
 install_manifest.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.DEFAULT_GOAL := build
+
+build:
+	cmake -S . -B build
+	cmake --build build
+
+pi:
+	cmake -S . -B build-pi -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
+	cmake --build build-pi
+
+clean:
+	rm -rf build build-pi

--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
 # pi-grid
 
-This repository hosts the code for the pi-grid project. The goal is to map grid inputs to MIDI events and run on a Raspberry Pi.
+This repository hosts the code for the pi-grid project. The goal is to map grid
+inputs to MIDI events and run on a Raspberry Pi.
 
-## Getting Started
+## macOS Setup
 
-This repository currently provides a minimal C build using CMake.  To build the
-`hello` binary locally, run the following commands from the project root:
+Run the bootstrap script to install Homebrew dependencies. It is safe to run
+multiple times as it skips already installed packages.
+
+```bash
+./scripts/bootstrap_macos.sh
+```
+
+## Building
+
+Build the native `hello` binary using CMake:
 
 ```bash
 cmake -S . -B build
 cmake --build build
 ```
 
-To cross-compile for an ARM target (e.g. Raspberry Pi), you will need the
-`aarch64-linux-gnu-gcc` toolchain installed.  Pass the provided toolchain file:
+Apple Silicon users can cross‑compile for Raspberry Pi with the `make pi`
+convenience target (uses `cmake/toolchain-arm64.cmake`).
 
 ```bash
-cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
-cmake --build build-arm64
+make pi
 ```
 
-The binary will be created at `build/hello` and simply prints `hello` when
-executed.  More functionality will land in subsequent epics.
+The resulting binary lives in `build` (or `build-pi` for cross‑compiled) and
+simply prints `hello` when executed.
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file
+for details.

--- a/scripts/bootstrap_macos.sh
+++ b/scripts/bootstrap_macos.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+REQUIRED=(libmonome alsa-lib pkg-config cmake aarch64-linux-gnu-gcc)
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Please install Homebrew from https://brew.sh/" >&2
+  exit 1
+fi
+
+for pkg in "${REQUIRED[@]}"; do
+  if brew list "$pkg" >/dev/null 2>&1; then
+    echo "[bootstrap] $pkg already installed"
+  else
+    echo "[bootstrap] Installing $pkg"
+    brew install "$pkg"
+  fi
+done
+
+echo "[bootstrap] Done. Open a new terminal to ensure PATH updates take effect."


### PR DESCRIPTION
## Summary
- add `bootstrap_macos.sh` to install Homebrew packages
- introduce a Makefile with `make` and `make pi`
- update `.gitignore` so top‐level Makefile is tracked
- document bootstrap script and cross‑compiling in README

## Testing
- `make clean && make`
- `make pi` *(fails: CMAKE_C_COMPILER not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8a8533948325b2e4f92bd9e51ea7