### PR TITLE
Implement Epic 3 note output

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,7 @@
 ## Epic 3 — Core Feature: Note Output
 | ID | Story | Done When |
 |---|---|---|
-|3.1|**Grid press → Note‑On** — Pressing any Grid key sends a MIDI **Note‑On** on channel 10 with velocity 100; mapping is `note = y*16 + x`.|Verified via `aseqdump` or DAW MIDI monitor.|
+|3.1|**Grid press → Note‑On** — Pressing any Grid key sends a MIDI **Note‑On** on channel 10 with velocity 100; mapping is `note = y*16 + x`. Requires `libmonome` and `alsa-lib`.|Verified via `aseqdump` or DAW MIDI monitor.|
 |3.2|**Grid release → Note‑Off** — Releasing the key sends a matching **Note‑Off** (or Note‑On vel 0) so notes stop sounding.|No stuck notes after frantic button mashing.|
 
 ## Epic 4 — System Integration & Deployment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,19 @@ project(pi_grid C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Optional dependencies
+find_package(PkgConfig)
+pkg_check_modules(LIBMONOME libmonome)
+pkg_check_modules(ALSA alsa)
+
 # Add the executable
 add_executable(hello src/main.c)
+
+# Link against libmonome and ALSA if available
+if(LIBMONOME_FOUND AND ALSA_FOUND)
+  target_compile_definitions(hello PRIVATE HAVE_LIBMONOME HAVE_ALSA)
+  target_include_directories(hello PRIVATE ${LIBMONOME_INCLUDE_DIRS} ${ALSA_INCLUDE_DIRS})
+  target_link_libraries(hello PRIVATE ${LIBMONOME_LIBRARIES} ${ALSA_LIBRARIES})
+else()
+  message(WARNING "Building without libmonome/ALSA; resulting binary prints hello only")
+endif()

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ convenience target (uses `cmake/toolchain-arm64.cmake`).
 make pi
 ```
 
-The resulting binary lives in `build` (or `build-pi` for cross‑compiled) and
-simply prints `hello` when executed.
+The resulting binary lives in `build` (or `build-pi` for cross‑compiled).
+When built with `libmonome` and `alsa-lib` available, running `./hello`
+listens for Grid key events and emits MIDI notes on channel 10 using the
+mapping `note = y*16 + x`. Without those libraries present, the program
+falls back to printing `hello`.
 
 ## License
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,75 @@
 #include <stdio.h>
 
+#if defined(HAVE_LIBMONOME) && defined(HAVE_ALSA)
+#include <monome.h>
+#include <alsa/asoundlib.h>
+
+static snd_seq_t *seq;
+static int out_port;
+
+static int xy_to_note(int x, int y) {
+    return y * 16 + x;
+}
+
+static void send_note(int note, int velocity) {
+    snd_seq_event_t ev;
+    snd_seq_ev_clear(&ev);
+    snd_seq_ev_set_source(&ev, out_port);
+    snd_seq_ev_set_subs(&ev);
+    snd_seq_ev_set_direct(&ev);
+    if (velocity) {
+        snd_seq_ev_set_noteon(&ev, 9, note, velocity);
+    } else {
+        snd_seq_ev_set_noteoff(&ev, 9, note, 0);
+    }
+    snd_seq_event_output(seq, &ev);
+    snd_seq_drain_output(seq);
+}
+
+static int handle_grid(const monome_event_t *e, void *data) {
+    int note = xy_to_note(e->grid.x, e->grid.y);
+    if (e->event_type == MONOME_BUTTON_DOWN) {
+        send_note(note, 100);
+    } else if (e->event_type == MONOME_BUTTON_UP) {
+        send_note(note, 0);
+    }
+    return 0;
+}
+
+int main(void) {
+    if (snd_seq_open(&seq, "default", SND_SEQ_OPEN_OUTPUT, 0) < 0) {
+        fprintf(stderr, "Failed to open ALSA sequencer\n");
+        return 1;
+    }
+    snd_seq_set_client_name(seq, "pi-grid");
+    out_port = snd_seq_create_simple_port(seq, "out",
+        SND_SEQ_PORT_CAP_READ|SND_SEQ_PORT_CAP_SUBS_READ,
+        SND_SEQ_PORT_TYPE_MIDI_GENERIC|SND_SEQ_PORT_TYPE_APPLICATION);
+    if (out_port < 0) {
+        fprintf(stderr, "Failed to create MIDI port\n");
+        return 1;
+    }
+
+    monome_t *monome = monome_open(NULL);
+    if (!monome) {
+        fprintf(stderr, "Unable to open monome\n");
+        return 1;
+    }
+
+    monome_register_handler(monome, MONOME_BUTTON_DOWN, handle_grid, NULL);
+    monome_register_handler(monome, MONOME_BUTTON_UP, handle_grid, NULL);
+    monome_event_loop(monome);
+
+    monome_close(monome);
+    snd_seq_close(seq);
+    return 0;
+}
+
+#else
+
 int main(void) {
     puts("hello");
     return 0;
 }
+
+#endif


### PR DESCRIPTION
## Summary
- add optional libmonome + ALSA detection to CMakeLists
- implement grid to MIDI note mapping in `src/main.c`
- describe new behaviour in README
- clarify dependencies in backlog

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/hello`

------
https://chatgpt.com/codex/tasks/task_e_683f8f635b108325a6d9efa3676736de