### PR TITLE
Implement systemd service and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config libmonome-dev libasound2-dev gcc-aarch64-linux-gnu
+      - name: Build
+        run: |
+          cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
+          cmake --build build --config Release
+      - name: Package
+        run: |
+          tar -C build -czf pi-grid-${{ github.ref_name }}.tar.gz pi-grid
+          cp contrib/grid-midi.service grid-midi.service
+          tar -rf pi-grid-${{ github.ref_name }}.tar.gz grid-midi.service
+          sha256sum pi-grid-${{ github.ref_name }}.tar.gz > pi-grid-${{ github.ref_name }}.sha256
+      - name: Upload release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            pi-grid-${{ github.ref_name }}.tar.gz
+            pi-grid-${{ github.ref_name }}.sha256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,15 @@ pkg_check_modules(LIBMONOME libmonome)
 pkg_check_modules(ALSA alsa)
 
 # Add the executable
-add_executable(hello src/main.c)
+add_executable(pi-grid src/main.c)
 
 # Link against libmonome and ALSA if available
 if(LIBMONOME_FOUND AND ALSA_FOUND)
-  target_compile_definitions(hello PRIVATE HAVE_LIBMONOME HAVE_ALSA)
-  target_include_directories(hello PRIVATE ${LIBMONOME_INCLUDE_DIRS} ${ALSA_INCLUDE_DIRS})
-  target_link_libraries(hello PRIVATE ${LIBMONOME_LIBRARIES} ${ALSA_LIBRARIES})
+  target_compile_definitions(pi-grid PRIVATE HAVE_LIBMONOME HAVE_ALSA)
+  target_include_directories(pi-grid PRIVATE ${LIBMONOME_INCLUDE_DIRS} ${ALSA_INCLUDE_DIRS})
+  target_link_libraries(pi-grid PRIVATE ${LIBMONOME_LIBRARIES} ${ALSA_LIBRARIES})
 else()
   message(WARNING "Building without libmonome/ALSA; resulting binary prints hello only")
 endif()
+
+install(TARGETS pi-grid RUNTIME DESTINATION bin)

--- a/PI_SETUP.md
+++ b/PI_SETUP.md
@@ -32,4 +32,16 @@ This guide prepares a fresh Raspberry Pi OS image so the `pi-grid` program can r
    ```
 4. If the client appears, the PiSound MIDI ports are ready to use.
 
+## 3. Run as a service
+1. Install the binary to `/usr/local/bin` (from your build directory):
+   ```bash
+   sudo cmake --install build
+   ```
+2. Copy the provided service unit and enable it:
+   ```bash
+   sudo cp contrib/grid-midi.service /etc/systemd/system/
+   sudo systemctl enable --now grid-midi
+   ```
+3. Reboot to verify the service starts automatically.
+
 Your Raspberry Pi is now configured to run the `pi-grid` application.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ multiple times as it skips already installed packages.
 
 ## Building
 
-Build the native `hello` binary using CMake:
+Build the native `pi-grid` binary using CMake:
 
 ```bash
 cmake -S . -B build
@@ -29,13 +29,13 @@ make pi
 ```
 
 The resulting binary lives in `build` (or `build-pi` for cross‑compiled).
-When built with `libmonome` and `alsa-lib` available, running `./hello`
+When built with `libmonome` and `alsa-lib` available, running `./pi-grid`
 listens for Grid key events and emits MIDI notes on channel 10 using the
 mapping `note = y*16 + x`. Without those libraries present, the program
 falls back to printing `hello`.
 
 ## Raspberry Pi Setup
-See [PI_SETUP.md](PI_SETUP.md) for preparing the Pi image and verifying PiSound.
+See [PI_SETUP.md](PI_SETUP.md) for preparing the Pi image, installing the systemd service, and verifying PiSound.
 
 ## License
 

--- a/contrib/grid-midi.service
+++ b/contrib/grid-midi.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=pi-grid MIDI service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/pi-grid
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- rename build target to `pi-grid` and add install step
- document new binary and service setup
- add systemd unit in `contrib`
- build & package on tag push via GitHub Actions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake --install build --prefix /tmp/testinstall`
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_683f9dbd6b3c8325b943f3fc981a6309