### PR TITLE
Implement Epic 5: tests and lint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 80

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install ARM cross-compiler
+    - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu clang clang-tidy clang-format
     - name: Configure (native)
-      run: cmake -S . -B build
+      run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Build (native)
       run: cmake --build build
+    - name: Run clang-format
+      run: ./scripts/check_format.sh
+    - name: Run clang-tidy
+      run: ./scripts/run_tidy.sh
+    - name: Run tests
+      run: |
+        cd build && ctest --output-on-failure
     - name: Configure (arm64)
-      run: cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake
+      run: cmake -S . -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm64.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Build (arm64)
       run: cmake --build build-arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,26 @@ project(pi_grid C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Enable testing
+enable_testing()
+
 # Optional dependencies
 find_package(PkgConfig)
 pkg_check_modules(LIBMONOME libmonome)
 pkg_check_modules(ALSA alsa)
 
+# Add library for shared utilities
+add_library(grid STATIC src/note_utils.c)
+target_include_directories(grid PUBLIC include)
+
 # Add the executable
 add_executable(hello src/main.c)
+target_link_libraries(hello PRIVATE grid)
+
+# Tests
+add_executable(test_note_utils tests/test_note_utils.c)
+target_link_libraries(test_note_utils PRIVATE grid)
+add_test(NAME note_utils COMMAND test_note_utils)
 
 # Link against libmonome and ALSA if available
 if(LIBMONOME_FOUND AND ALSA_FOUND)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ listens for Grid key events and emits MIDI notes on channel 10 using the
 mapping `note = y*16 + x`. Without those libraries present, the program
 falls back to printing `hello`.
 
+## Testing
+
+Run the unit tests with CTest after building:
+
+```bash
+cd build && ctest
+```
+
 ## Raspberry Pi Setup
 See [PI_SETUP.md](PI_SETUP.md) for preparing the Pi image and verifying PiSound.
 

--- a/include/note_utils.h
+++ b/include/note_utils.h
@@ -1,0 +1,6 @@
+#ifndef NOTE_UTILS_H
+#define NOTE_UTILS_H
+
+int xy_to_note(int x, int y);
+
+#endif // NOTE_UTILS_H

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+files=$(git ls-files '*.c' '*.h')
+
+need_fmt=0
+for f in $files; do
+    if ! clang-format -style=file "$f" | diff -u "$f" - >/dev/null; then
+        echo "File $f is not properly formatted"
+        need_fmt=1
+    fi
+done
+
+exit $need_fmt

--- a/scripts/run_tidy.sh
+++ b/scripts/run_tidy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+files=$(git ls-files '*.c')
+
+for f in $files; do
+    clang-tidy "$f" -- -Iinclude
+done

--- a/src/main.c
+++ b/src/main.c
@@ -1,15 +1,12 @@
 #include <stdio.h>
 
 #if defined(HAVE_LIBMONOME) && defined(HAVE_ALSA)
-#include <monome.h>
+#include "note_utils.h"
 #include <alsa/asoundlib.h>
+#include <monome.h>
 
 static snd_seq_t *seq;
 static int out_port;
-
-static int xy_to_note(int x, int y) {
-    return y * 16 + x;
-}
 
 static void send_note(int note, int velocity) {
     snd_seq_event_t ev;
@@ -42,9 +39,9 @@ int main(void) {
         return 1;
     }
     snd_seq_set_client_name(seq, "pi-grid");
-    out_port = snd_seq_create_simple_port(seq, "out",
-        SND_SEQ_PORT_CAP_READ|SND_SEQ_PORT_CAP_SUBS_READ,
-        SND_SEQ_PORT_TYPE_MIDI_GENERIC|SND_SEQ_PORT_TYPE_APPLICATION);
+    out_port = snd_seq_create_simple_port(
+        seq, "out", SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ,
+        SND_SEQ_PORT_TYPE_MIDI_GENERIC | SND_SEQ_PORT_TYPE_APPLICATION);
     if (out_port < 0) {
         fprintf(stderr, "Failed to create MIDI port\n");
         return 1;

--- a/src/note_utils.c
+++ b/src/note_utils.c
@@ -1,0 +1,3 @@
+#include "note_utils.h"
+
+int xy_to_note(int x, int y) { return y * 16 + x; }

--- a/tests/test_note_utils.c
+++ b/tests/test_note_utils.c
@@ -1,0 +1,15 @@
+#include "note_utils.h"
+#include <assert.h>
+
+int main(void) {
+    // Test corners of an 8x8 grid
+    assert(xy_to_note(0, 0) == 0);
+    assert(xy_to_note(7, 0) == 7);
+    assert(xy_to_note(0, 7) == 112);
+    assert(xy_to_note(7, 7) == 119);
+
+    // Test middle
+    assert(xy_to_note(3, 4) == 67);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- factor note mapping code into a reusable library
- add unit test for `xy_to_note`
- add clang-format and clang-tidy configs with helper scripts
- update CI to run formatting checks, clang-tidy and tests
- document running tests in README

## Testing
- `cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build .`
- `ctest --output-on-failure`
- `./scripts/check_format.sh`
- `./scripts/run_tidy.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f9dc8bcac83258144bd7de7f0d908